### PR TITLE
Claim names are not required for XRDs

### DIFF
--- a/internal/xpkg/lint/schema/store.go
+++ b/internal/xpkg/lint/schema/store.go
@@ -41,11 +41,13 @@ func (s *SchemaStore) RegisterPackage(pkg *xpkg.Package) error {
 				return errors.Wrap(err, errBuildCompositeCRD)
 			}
 			s.registerCRD(comp)
-			claim, err := ForCompositeResourceClaim(xrd)
-			if err != nil {
-				return errors.Wrap(err, errBuildClaimCRD)
+			if xrd.Spec.ClaimNames != nil {
+				claim, err := ForCompositeResourceClaim(xrd)
+				if err != nil {
+					return errors.Wrap(err, errBuildClaimCRD)
+				}
+				s.registerCRD(claim)
 			}
-			s.registerCRD(claim)
 		}
 	}
 	return nil


### PR DESCRIPTION
# What

Address [Issue 1](https://github.com/crossplane-contrib/crossplane-lint/issues/1), there is no requirement for CompositeResourceDefinitions to have a claim name and thus no claim should be checked if the spec is nil.

I believe this is an appropriate solution to just not attempt to registerCRD for the claim as this is an optional field on the spec https://pkg.go.dev/github.com/crossplane/crossplane@v1.11.2/apis/apiextensions/v1#CompositeResourceDefinitionSpec

# Testing

I've built this locally and tested my own test crd.  Previously I was also failing this lint test with the same issue

```
crossplane-lint: error: failed to register package schemas: failed to build claim CRD: invalid resource claim names: missing names
```

It now succeeds after