### PR TITLE
Add uid field to addMetaDataToSchema func

### DIFF
--- a/internal/xpkg/lint/schema/store.go
+++ b/internal/xpkg/lint/schema/store.go
@@ -90,6 +90,9 @@ func addMetaDataToSchema(crdv *extv1.CustomResourceDefinitionVersion) {
 				},
 			},
 		},
+		"uid": {
+			Type: "string",
+		},
 	}
 	if crdv.Schema == nil {
 		crdv.Schema = &extv1.CustomResourceValidation{}


### PR DESCRIPTION
When `metadata.uid` is referenced in a patch, crossplane-lint now throws an error because the field doesn't exist in the defenition.
Adding it to the `addMetaDataToSchema` func enables you to use it in patches to generate some unique names for example.